### PR TITLE
Security: GitHub Actions pinnen op volledige commit-SHA

### DIFF
--- a/.github/workflows/check_on_branch.yml
+++ b/.github/workflows/check_on_branch.yml
@@ -19,13 +19,13 @@ jobs:
       ORCID_TOKEN: ${{ secrets.ORCID_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
-      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: release
 
-      - uses: r-lib/actions/setup-pandoc@v2
+      - uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 
       - name: Install system dependencies
         run: |
@@ -76,7 +76,7 @@ jobs:
 
       - name: Upload check results
         if: failure()
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@0c366cb4fc8897159c94880f94b55bc716ad6a66 # master
         with:
           name: ${{ runner.os }}-r${{ matrix.config.r }}-results
           path: check

--- a/.github/workflows/check_on_different_r_os.yml
+++ b/.github/workflows/check_on_different_r_os.yml
@@ -31,14 +31,14 @@ jobs:
       ORCID_TOKEN: ${{ secrets.ORCID_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
-      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: ${{ matrix.config.r }}
           extra-repositories: https://inbo.r-universe.dev
 
-      - uses: r-lib/actions/setup-pandoc@v2
+      - uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 
       - name: linux dependencies
         if: runner.os == 'linux'
@@ -58,7 +58,7 @@ jobs:
           Rscript --no-save --no-restore -e 'install.packages("remotes")'
           Rscript --no-save --no-restore -e 'remotes::install_cran(c("assertthat", "bookdown", "codemetar", "covr", "curl", "cyclocomp", "desc", "devtools", "fs", "gert", "hexSticker", "httr", "hunspell", "jsonlite", "knitr", "lintr", "mockery", "pdftools", "pkgdown", "R6", "rcmdcheck", "renv", "rmarkdown", "roxygen2", "rstudioapi", "sessioninfo", "showtext", "sysfonts", "testthat", "withr", "yaml"))'
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
+      - uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         if: runner.os != 'linux'
         with:
           extra-packages: any::rcmdcheck
@@ -91,7 +91,7 @@ jobs:
 
       - name: Upload check results
         if: failure()
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@0c366cb4fc8897159c94880f94b55bc716ad6a66 # master
         with:
           name: ${{ runner.os }}-r${{ matrix.config.r }}-results
           path: check

--- a/.github/workflows/check_on_main.yml
+++ b/.github/workflows/check_on_main.yml
@@ -17,13 +17,13 @@ jobs:
       ORCID_TOKEN: ${{ secrets.ORCID_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
-      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: release
 
-      - uses: r-lib/actions/setup-pandoc@v2
+      - uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 
       - name: Install system dependencies
         run: |
@@ -71,7 +71,7 @@ jobs:
 
       - name: Upload check results
         if: failure()
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@0c366cb4fc8897159c94880f94b55bc716ad6a66 # master
         with:
           name: ${{ runner.os }}-r${{ matrix.config.r }}-results
           path: check

--- a/.github/workflows/lint_on_branch.yaml
+++ b/.github/workflows/lint_on_branch.yaml
@@ -17,13 +17,13 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.PAT }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
+      - uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           extra-packages: any::lintr, local::.
           needs: lint

--- a/.github/workflows/lint_on_branch.yaml
+++ b/.github/workflows/lint_on_branch.yaml
@@ -17,13 +17,13 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.PAT }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::lintr, local::.
           needs: lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Get tag
         run: |
           git fetch --tags --force
@@ -23,7 +23,7 @@ jobs:
           TAG_BODY=$(git tag --contains $(git rev-parse HEAD) --format='%(contents)')
           echo "tag=$TAG" >> $GITHUB_ENV
           echo "$TAG_BODY" > body.md
-      - uses: ncipollo/release-action@v1
+      - uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
         with:
           name: Release ${{ env.tag }}
           tag: ${{ env.tag }}

--- a/.github/workflows/remove_old_artifacts.yml
+++ b/.github/workflows/remove_old_artifacts.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - name: Remove old artifacts
-      uses: c-hive/gha-remove-artifacts@v1
+      uses: c-hive/gha-remove-artifacts@44fc7acaf1b3d0987da0e8d4707a989d80e9554b # v1
       with:
         age: '1 days'
         skip-recent: 4


### PR DESCRIPTION
_Onderdeel van een INBO-brede security-hardening: SHA-pinning van GitHub Actions. Aanbevolen door o.a. [GitHub Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)._